### PR TITLE
fix: bad command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,7 @@ gcloud services enable cloudresourcemanager.googleapis.com compute.googleapis.co
 ```
 
 2. Service Quota increase: `In-use IP addresses (default is 8)` has too low of a default value for deploying Kubernetes and quota should be increased to 64 to create headroom in available IPs.
-Edit the quota for `In-use IP addresses` in the [quota page](https://console.cloud.google.com/iam-admin/quotas) or with the following `gcloud` command.
-
-```bash
-gcloud alpha services quota update \
-    --service=compute.googleapis.com --consumer=projects/<your-project-name> \
-    --metric=compute.googleapis.com/global_in_use_addresses \
-    --unit=1/{project} --value=64
-```
+Edit the quota for `In-use IP addresses` in the [quota page](https://console.cloud.google.com/iam-admin/quotas)
 \_Note: If the increase isn't immediate or you receive an error, contact GCP support/account management\_
 
 ![Screenshot of Quota Increase](https://user-images.githubusercontent.com/6570292/210277244-f3a75d06-763f-4bdc-805e-4f8bd3c77ad5.png)

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -13,15 +13,7 @@ gcloud services enable cloudresourcemanager.googleapis.com compute.googleapis.co
 ```
 
 2. Service Quota increase: `In-use IP addresses (default is 8)` has too low of a default value for deploying Kubernetes and quota should be increased to 64 to create headroom in available IPs.
-Edit the quota for `In-use IP addresses` in the [quota page](https://console.cloud.google.com/iam-admin/quotas) or with the following `gcloud` command.
-
-
-```bash
-gcloud alpha services quota update \
-    --service=compute.googleapis.com --consumer=projects/<your-project-name> \
-    --metric=compute.googleapis.com/global_in_use_addresses \
-    --unit=1/{project} --value=64
-```
+Edit the quota for `In-use IP addresses` in the [quota page](https://console.cloud.google.com/iam-admin/quotas)
 _Note: If the increase isn't immediate or you receive an error, contact GCP support/account management_
 
 


### PR DESCRIPTION
@fernandoataoldotcom just ran it again and had the same error:

venkata_mutyala@cloudshell:~ (venkata-test-2-np)$ gcloud alpha services quota update     --service=compute.googleapis.com --consumer=projects/venkata-test-2-np     --metric=compute.googleapis.com/global_in_use_addresses     --unit=1/{project} --value=64
ERROR: (gcloud.alpha.services.quota.update) FAILED_PRECONDITION: The consumer override value can only be set between 0 to 8.
Help Token: AXywVyT
- '@type': type.googleapis.com/google.rpc.PreconditionFailure
  violations:
  - subject: ?error_code=101038&max=8
    type: googleapis.com
- '@type': type.googleapis.com/google.rpc.ErrorInfo
  domain: serviceusage.googleapis.com
  metadata:
    max: '8'
  reason: COMMON_QUOTA_CONSUMER_OVERRIDE_TOO_HIGH
venkata_mutyala@cloudshell:~ (venkata-test-2-np)$