### PR TITLE
fix: example with correct gke version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ module "captain" {
       disk_size_gb       = 30
       auto_upgrade       = false
       auto_repair        = true
-      gke_version        = "1.26.3-gke.1000"
+      gke_version        = "1.25.8-gke.500"
       node_count         = 3
       spot               = true
     }
   ]
-  gke_version = "1.26.3-gke.1000"
+  gke_version = "1.25.8-gke.500"
 }
 ```
 

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -33,12 +33,12 @@ module "captain" {
       disk_size_gb       = 30
       auto_upgrade       = false
       auto_repair        = true
-      gke_version        = "1.26.3-gke.1000"
+      gke_version        = "1.25.8-gke.500"
       node_count         = 3
       spot               = true
     }
   ]
-  gke_version = "1.26.3-gke.1000"
+  gke_version = "1.25.8-gke.500"
 }
 ```
 


### PR DESCRIPTION
It seems the GKE versions haven't fully been released across all the regions yet. I had to query with a cli command to get the current versions in us-central1. Probably another week before it lands in us-central1