### PR TITLE
fix: use older gke version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.11-gke.1019000"
+      gke_version  = "1.28.10-gke.1141000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -60,7 +60,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.11-gke.1019000"
+      gke_version  = "1.28.10-gke.1141000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -69,7 +69,7 @@ module "captain" {
       kubernetes_taints = []
     },
   ]
-  gke_version = "1.28.11-gke.1019000"
+  gke_version = "1.28.10-gke.1141000"
   network_peering_configurations = [
 #    {
 #    peer_network                        = "projects/example-project/global/networks/example-network-2"

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -36,7 +36,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.11-gke.1019000"
+      gke_version  = "1.28.10-gke.1141000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -59,7 +59,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.11-gke.1019000"
+      gke_version  = "1.28.10-gke.1141000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -68,7 +68,7 @@ module "captain" {
       kubernetes_taints = []
     },
   ]
-  gke_version = "1.28.11-gke.1019000"
+  gke_version = "1.28.10-gke.1141000"
   network_peering_configurations = [
 #    {
 #    peer_network                        = "projects/example-project/global/networks/example-network-2"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Downgraded the GKE version from `1.28.11-gke.1019000` to `1.28.10-gke.1141000` in the documentation file `docs/.header.md`.
- This change affects multiple instances of the `gke_version` parameter within the file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.header.md</strong><dd><code>Downgrade GKE version in documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/.header.md

<li>Updated the <code>gke_version</code> from <code>1.28.11-gke.1019000</code> to <br><code>1.28.10-gke.1141000</code> in multiple instances.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-gcp-kubernetes-cluster/pull/52/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

