### PR TITLE
fix: gke version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.10-gke.1141000"
+      gke_version  = "1.28.10-gke.1148000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -60,7 +60,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.10-gke.1141000"
+      gke_version  = "1.28.10-gke.1148000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -69,7 +69,7 @@ module "captain" {
       kubernetes_taints = []
     },
   ]
-  gke_version = "1.28.10-gke.1141000"
+  gke_version = "1.28.10-gke.1148000"
   network_peering_configurations = [
 #    {
 #    peer_network                        = "projects/example-project/global/networks/example-network-2"

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -36,7 +36,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.10-gke.1141000"
+      gke_version  = "1.28.10-gke.1148000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -59,7 +59,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.10-gke.1141000"
+      gke_version  = "1.28.10-gke.1148000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -68,7 +68,7 @@ module "captain" {
       kubernetes_taints = []
     },
   ]
-  gke_version = "1.28.10-gke.1141000"
+  gke_version = "1.28.10-gke.1148000"
   network_peering_configurations = [
 #    {
 #    peer_network                        = "projects/example-project/global/networks/example-network-2"


### PR DESCRIPTION
### **PR Type**
Bug fix, Documentation


___

### **Description**
- Updated the `gke_version` from `1.28.10-gke.1141000` to `1.28.10-gke.1148000` in the documentation examples.
- Ensured consistency in the GKE version used across the documentation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.header.md</strong><dd><code>Update GKE version in documentation examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/.header.md

- Updated the `gke_version` value in multiple instances.



</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-gcp-kubernetes-cluster/pull/53/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

