### PR TITLE
fix: adding node pool that's required for argocd app controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ module "captain" {
       ]
     },
     {
+      name         = "glueops-platform-node-pool-argocd-app-controller-1"
+      machine_type = "c2-standard-4"
+      disk_type    = "pd-standard"
+      disk_size_gb = 30
+      auto_upgrade = false
+      auto_repair  = true
+      gke_version  = "1.28.10-gke.1148000"
+      node_count   = 2
+      spot         = false
+      preemptible  = false
+      node_pool_zones = ["a","b"]
+      kubernetes_labels = {
+        "glueops.dev/role" : "glueops-platform-argocd-app-controller"
+      }
+      kubernetes_taints = [
+        {
+          key    = "glueops.dev/role"
+          value  = "glueops-platform-argocd-app-controller"
+          effect = "NO_SCHEDULE"
+        }
+      ]
+    },
+    {
       name         = "clusterwide-node-pool-1"
       machine_type = "c2-standard-4"
       disk_type    = "pd-standard"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ module "captain" {
       ]
     },
     {
-      name         = "glueops-platform-node-pool-argocd-app-controller-1"
+      name         = "glueops-node-pool-argocd-app-ctrl-1"
       machine_type = "c2-standard-4"
       disk_type    = "pd-standard"
       disk_size_gb = 30

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -53,7 +53,7 @@ module "captain" {
       ]
     },
     {
-      name         = "glueops-platform-node-pool-argocd-app-controller-1"
+      name         = "glueops-node-pool-argocd-app-ctrl-1"
       machine_type = "c2-standard-4"
       disk_type    = "pd-standard"
       disk_size_gb = 30

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -53,6 +53,29 @@ module "captain" {
       ]
     },
     {
+      name         = "glueops-platform-node-pool-argocd-app-controller-1"
+      machine_type = "c2-standard-4"
+      disk_type    = "pd-standard"
+      disk_size_gb = 30
+      auto_upgrade = false
+      auto_repair  = true
+      gke_version  = "1.28.10-gke.1148000"
+      node_count   = 2
+      spot         = false
+      preemptible  = false
+      node_pool_zones = ["a","b"]
+      kubernetes_labels = {
+        "glueops.dev/role" : "glueops-platform-argocd-app-controller"
+      }
+      kubernetes_taints = [
+        {
+          key    = "glueops.dev/role"
+          value  = "glueops-platform-argocd-app-controller"
+          effect = "NO_SCHEDULE"
+        }
+      ]
+    },
+    {
       name         = "clusterwide-node-pool-1"
       machine_type = "c2-standard-4"
       disk_type    = "pd-standard"


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added a new node pool configuration named `glueops-platform-node-pool-argocd-app-controller-1` to the documentation.
- Specified various parameters including `machine_type`, `disk_type`, `disk_size_gb`, `auto_upgrade`, `auto_repair`, `gke_version`, `node_count`, `spot`, `preemptible`, and `node_pool_zones`.
- Included Kubernetes labels and taints for the new node pool to ensure proper scheduling and role assignment.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.header.md</strong><dd><code>Add node pool configuration for ArgoCD app controller</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/.header.md

<li>Added a new node pool configuration for ArgoCD app controller.<br> <li> Specified machine type, disk type, disk size, and other parameters.<br> <li> Included Kubernetes labels and taints for the new node pool.<br>


</details>
    

  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-gcp-kubernetes-cluster/pull/54/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+23/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

