### PR TITLE
feat: update to august 7th stable versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.12-gke.1179000"
+      gke_version  = "1.28.11-gke.1172000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -60,7 +60,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.12-gke.1179000"
+      gke_version  = "1.28.11-gke.1172000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -83,7 +83,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.12-gke.1179000"
+      gke_version  = "1.28.11-gke.1172000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -92,7 +92,7 @@ module "captain" {
       kubernetes_taints = []
     },
   ]
-  gke_version = "1.28.12-gke.1179000"
+  gke_version = "1.28.11-gke.1172000"
   network_peering_configurations = [
 #    {
 #    peer_network                        = "projects/example-project/global/networks/example-network-2"

--- a/docs/.header.md
+++ b/docs/.header.md
@@ -36,7 +36,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.12-gke.1179000"
+      gke_version  = "1.28.11-gke.1172000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -59,7 +59,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.12-gke.1179000"
+      gke_version  = "1.28.11-gke.1172000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -82,7 +82,7 @@ module "captain" {
       disk_size_gb = 30
       auto_upgrade = false
       auto_repair  = true
-      gke_version  = "1.28.12-gke.1179000"
+      gke_version  = "1.28.11-gke.1172000"
       node_count   = 2
       spot         = false
       preemptible  = false
@@ -91,7 +91,7 @@ module "captain" {
       kubernetes_taints = []
     },
   ]
-  gke_version = "1.28.12-gke.1179000"
+  gke_version = "1.28.11-gke.1172000"
   network_peering_configurations = [
 #    {
 #    peer_network                        = "projects/example-project/global/networks/example-network-2"


### PR DESCRIPTION
### **User description**
https://cloud.google.com/kubernetes-engine/docs/release-notes-stable#August_07_2024


___

### **PR Type**
enhancement


___

### **Description**
- Downgraded the GKE version from `1.28.12-gke.1179000` to `1.28.11-gke.1172000` in the `docs/.header.md` file.
- The changes affect several node pool configurations, ensuring consistency across the document.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.header.md</strong><dd><code>Update GKE version in node pool configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/.header.md

<li>Updated GKE version from <code>1.28.12-gke.1179000</code> to <code>1.28.11-gke.1172000</code>.<br> <li> Changes applied to multiple node pool configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/terraform-module-cloud-gcp-kubernetes-cluster/pull/58/files#diff-1a920578bc3e05f584ae3733aa0a891fa9af5fbae8afe498215e2df849598eb4">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

